### PR TITLE
Potential fix for code scanning alert no. 6: Unvalidated dynamic method call

### DIFF
--- a/scripts/next-remote-watch.js
+++ b/scripts/next-remote-watch.js
@@ -113,22 +113,38 @@ app.prepare().then(() => {
     // log message if present
     const msg = req.body.message;
     const color = req.body.color;
-    const allowedColorFormatters = {
-      red: chalk.red,
-      green: chalk.green,
-      yellow: chalk.yellow,
-      blue: chalk.blue,
-      magenta: chalk.magenta,
-      cyan: chalk.cyan,
-      white: chalk.white,
-      gray: chalk.gray,
-    };
     if (msg) {
-      const hasValidColorMethod =
-        typeof color === 'string' &&
-        Object.prototype.hasOwnProperty.call(allowedColorFormatters, color);
-      const colorFormatter = hasValidColorMethod ? allowedColorFormatters[color] : null;
-      const formattedMsg = colorFormatter ? colorFormatter(msg) : msg;
+      let formattedMsg = msg;
+      if (typeof color === 'string') {
+        switch (color) {
+          case 'red':
+            formattedMsg = chalk.red(msg);
+            break;
+          case 'green':
+            formattedMsg = chalk.green(msg);
+            break;
+          case 'yellow':
+            formattedMsg = chalk.yellow(msg);
+            break;
+          case 'blue':
+            formattedMsg = chalk.blue(msg);
+            break;
+          case 'magenta':
+            formattedMsg = chalk.magenta(msg);
+            break;
+          case 'cyan':
+            formattedMsg = chalk.cyan(msg);
+            break;
+          case 'white':
+            formattedMsg = chalk.white(msg);
+            break;
+          case 'gray':
+            formattedMsg = chalk.gray(msg);
+            break;
+          default:
+            formattedMsg = msg;
+        }
+      }
       console.log(formattedMsg);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/imjimit07/imjimit07-vercel/security/code-scanning/6](https://github.com/imjimit07/imjimit07-vercel/security/code-scanning/6)

General fix: avoid user-controlled dynamic lookup for callable targets. Replace it with explicit selection logic (for example `switch`) and only invoke known function references.

Best fix here (without changing functionality): in `scripts/next-remote-watch.js`, replace the `allowedColorFormatters[color]` lookup and subsequent call with a `switch (color)` that directly applies the matching `chalk` method. This preserves behavior (same supported colors + fallback to plain message) while eliminating dynamic method dispatch entirely.

Changes needed:
- In the reload route handler around lines 116–132:
  - Remove `allowedColorFormatters`, `hasValidColorMethod`, and `colorFormatter`.
  - Introduce `let formattedMsg = msg;` and `switch (color)` assigning `formattedMsg = chalk.<color>(msg)` for supported colors.
  - Keep fallback default as plain `msg`.
- No new imports, methods, or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
